### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deployment-digital-ocean.yml
+++ b/.github/workflows/deployment-digital-ocean.yml
@@ -16,7 +16,7 @@ jobs:
       - run: echo ::set-env name=IMAGE_DOCKER_NAME::$(echo ${GITHUB_REPOSITORY})
 
       - name: Building image and Publish image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: "${{ env.IMAGE_DOCKER_NAME }}/test-github-actions"
           username: ${{ secrets.USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore